### PR TITLE
Display expense account names in invoice creation

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -9,7 +9,6 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
 import ExpenseSetup from "./pages/ExpenseSetup";
-import VendorTypes from "./pages/VendorTypes";
 import Vendors from "./pages/Vendors";
 import VendorDetails from "./pages/VendorDetails";
 import VendorEdit from "./pages/VendorEdit";
@@ -37,7 +36,6 @@ const App = () => (
           <Routes>
             <Route path="/" element={<Index />} />
             <Route path="/expense/setup" element={<ExpenseSetup />} />
-            <Route path="/expense/vendor-types" element={<VendorTypes />} />
             <Route path="/vendors" element={<Vendors />} />
             <Route path="/vendors/:id" element={<VendorDetails />} />
             <Route path="/vendors/:id/edit" element={<VendorEdit />} />

--- a/client/components/AppShell.tsx
+++ b/client/components/AppShell.tsx
@@ -51,11 +51,6 @@ export function AppShell({ children }: { children: ReactNode }) {
                     </SidebarMenuButton>
                   </SidebarMenuItem>
                   <SidebarMenuItem>
-                    <SidebarMenuButton asChild isActive={isActive("/expense/vendor-types")}> 
-                      <Link to="/expense/vendor-types">Vendor Types</Link>
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                  <SidebarMenuItem>
                     <SidebarMenuButton asChild isActive={isActive("/vendors")}> 
                       <Link to="/vendors">Vendors</Link>
                     </SidebarMenuButton>

--- a/client/pages/CreateInvoice.tsx
+++ b/client/pages/CreateInvoice.tsx
@@ -30,8 +30,8 @@ export default function CreateInvoicePage() {
   const allowedAccounts = useMemo(() => {
     return Array.from(new Set(pr?.items.map((i) => i.accountId) || []));
   }, [pr]);
-  type Row = { id: string; accountId: string; amount: string; gstPct: string; tdsPct: string };
-  const emptyRow = (): Row => ({ id: id("ROW"), accountId: "", amount: "", gstPct: "", tdsPct: "" });
+  type Row = { id: string; accountId: string; amount: string; hsnCode: string; tdsSection: string; gstPct: string; tdsPct: string };
+  const emptyRow = (): Row => ({ id: id("ROW"), accountId: "", amount: "", hsnCode: "", tdsSection: "", gstPct: "", tdsPct: "" });
   const [rows, setRows] = useState<Row[]>([emptyRow()]);
   const addRow = () => setRows((s) => [...s, emptyRow()]);
   const removeRow = (rid: string) => setRows((s) => s.filter((r) => r.id !== rid));
@@ -55,7 +55,7 @@ export default function CreateInvoicePage() {
     !!date &&
     !!dueDate &&
     rows.length > 0 &&
-    rows.every((r) => r.accountId && Number(r.amount) > 0) &&
+    rows.every((r) => r.accountId && Number(r.amount) > 0 && !!r.hsnCode && !!r.tdsSection) &&
     !exceeds &&
     total > 0;
 
@@ -162,6 +162,12 @@ export default function CreateInvoicePage() {
                             </Field>
                             <Field label="Amount *">
                               <Input value={r.amount} onChange={(e) => updateRow(r.id, { amount: e.target.value })} />
+                            </Field>
+                            <Field label="HSN Code *">
+                              <Input value={r.hsnCode} onChange={(e) => updateRow(r.id, { hsnCode: e.target.value })} />
+                            </Field>
+                            <Field label="TDS Section Code *">
+                              <Input value={r.tdsSection} onChange={(e) => updateRow(r.id, { tdsSection: e.target.value })} />
                             </Field>
                           </div>
                           <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">

--- a/client/pages/CreateInvoice.tsx
+++ b/client/pages/CreateInvoice.tsx
@@ -155,7 +155,7 @@ export default function CreateInvoicePage() {
                                 </SelectTrigger>
                                 <SelectContent>
                                   {allowedAccounts.map((acc) => (
-                                    <SelectItem key={acc} value={acc}>{acc}</SelectItem>
+                                    <SelectItem key={acc} value={acc}>{useExpense().accounts.find((a)=>a.id===acc)?.name || acc}</SelectItem>
                                   ))}
                                 </SelectContent>
                               </Select>

--- a/client/pages/ExpenseSetup.tsx
+++ b/client/pages/ExpenseSetup.tsx
@@ -8,6 +8,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 import { useMemo, useState } from "react";
+import { useExpense } from "@/store/expense";
 
 interface Group {
   id: string;
@@ -32,7 +33,7 @@ export default function ExpenseSetup() {
   const [query, setQuery] = useState("");
 
   const [groups, setGroups] = useState<Group[]>([]);
-  const [accounts, setAccounts] = useState<ExpenseAccount[]>([]);
+  const { accounts, addAccount, updateAccount, removeAccount } = useExpense();
 
   const filteredGroups = useMemo(
     () =>
@@ -90,8 +91,8 @@ export default function ExpenseSetup() {
             ) : (
               <AddAccountButton
                 groups={groups}
-                accounts={accounts}
-                onSave={(a) => setAccounts((s) => [...s, a])}
+                accounts={accounts as any}
+                onSave={(a) => addAccount(a as any)}
               />
             )}
           </div>
@@ -110,13 +111,11 @@ export default function ExpenseSetup() {
           />
         ) : (
           <AccountsTable
-            items={filteredAccounts}
+            items={filteredAccounts as any}
             groups={groups}
-            onToggle={(id) =>
-              setAccounts((s) => s.map((a) => (a.id === id ? { ...a, active: !a.active } : a)))
-            }
-            onDelete={(id) => setAccounts((s) => s.filter((a) => a.id !== id))}
-            onEdit={(a) => setAccounts((s) => s.map((it) => (it.id === a.id ? a : it)))}
+            onToggle={(id) => updateAccount({ ...(accounts.find(a=>a.id===id) as any), active: !(accounts.find(a=>a.id===id) as any)?.active })}
+            onDelete={(id) => removeAccount(id)}
+            onEdit={(a) => updateAccount(a as any)}
           />
         )}
       </div>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -19,13 +19,6 @@ export default function Index() {
             action="Open"
           />
           <FeatureCard
-            title="Vendor Types"
-            description="Define and manage vendor categories"
-            icon={<Users className="h-5 w-5" />}
-            to="/expense/vendor-types"
-            action="Manage"
-          />
-          <FeatureCard
             title="Purchase Workflow"
             description="Create and track PRs"
             icon={<FileText className="h-5 w-5" />}

--- a/client/pages/PaymentVoucherCreate.tsx
+++ b/client/pages/PaymentVoucherCreate.tsx
@@ -170,8 +170,8 @@ export default function PaymentVoucherCreate() {
                   Invoice
                 </label>
                 <label className="inline-flex items-center gap-2">
-                  <input type="radio" className="accent-[hsl(var(--primary))]" checked={payType === "Advance"} onChange={() => setPayType("Advance")} />
-                  Advance Payment
+                  <input type="radio" className="accent-[hsl(var(--primary))]" checked={payType === "General"} onChange={() => setPayType("General")} />
+                  General Payment
                 </label>
               </div>
 

--- a/client/pages/PaymentVoucherCreate.tsx
+++ b/client/pages/PaymentVoucherCreate.tsx
@@ -21,7 +21,7 @@ export default function PaymentVoucherCreate() {
   const [desc, setDesc] = useState("");
   const [file, setFile] = useState<File | null>(null);
 
-  const [payType, setPayType] = useState<"Invoice" | "Advance">("Invoice");
+  const [payType, setPayType] = useState<"Invoice" | "General">("Invoice");
   const [selectedInvoiceIds, setSelectedInvoiceIds] = useState<string[]>([]);
   const [invoiceAmounts, setInvoiceAmounts] = useState<Record<string, number>>({});
   const [advanceAmount, setAdvanceAmount] = useState<number>(0);

--- a/client/pages/PurchaseRequest.tsx
+++ b/client/pages/PurchaseRequest.tsx
@@ -318,6 +318,9 @@ function EditPR({
                       <Input value={it.total} readOnly />
                     </Field>
 
+                    <Field label="HSN Code (optional)">
+                      <Input value={(it as any).hsnCode || ""} onChange={(e)=> updateItem(setItems, idx, { hsnCode: e.target.value } as any)} placeholder="HSN" />
+                    </Field>
                     <Field label="GST %">
                       <PercentCombobox
                         value={it.gstRate || ""}
@@ -581,6 +584,9 @@ function CreatePR({ onSave }: { onSave: (p: PR) => void }) {
                       <Input value={it.total} readOnly />
                     </Field>
 
+                    <Field label="HSN Code (optional)">
+                      <Input value={(it as any).hsnCode || ""} onChange={(e)=> updateItem(setItems, idx, { hsnCode: e.target.value } as any)} placeholder="HSN" />
+                    </Field>
                     <Field label="GST %">
                       <PercentCombobox
                         value={it.gstRate || ""}

--- a/client/pages/PurchaseRequest.tsx
+++ b/client/pages/PurchaseRequest.tsx
@@ -707,11 +707,10 @@ function emptyItem(): PRItem {
     unitPrice: 0,
     total: 0,
     gstRate: "0",
-    tdsRate: "0",
     gstAmount: 0,
     tdsAmount: 0,
     payable: 0,
-  };
+  } as any;
 }
 function updateItem(
   setter: React.Dispatch<React.SetStateAction<PRItem[]>>,

--- a/client/pages/PurchaseRequest.tsx
+++ b/client/pages/PurchaseRequest.tsx
@@ -394,6 +394,7 @@ function CreatePR({ onSave }: { onSave: (p: PR) => void }) {
   const [title, setTitle] = useState("");
   const [vendorId, setVendorId] = useState("");
   const [requestDate, setRequestDate] = useState("");
+  const [requesterName, setRequesterName] = useState("");
   const [document, setDocument] = useState<File | null>(null);
   const [items, setItems] = useState<PRItem[]>([emptyItem()]);
   const { vendors } = useExpense();
@@ -412,6 +413,7 @@ function CreatePR({ onSave }: { onSave: (p: PR) => void }) {
       title: title.trim(),
       vendorId,
       requestDate,
+      requesterName: requesterName || undefined,
       documentName: document?.name,
       poNumber: nextPONumber(yr),
       items,
@@ -465,6 +467,9 @@ function CreatePR({ onSave }: { onSave: (p: PR) => void }) {
                   value={requestDate}
                   onChange={(e) => setRequestDate(e.target.value)}
                 />
+              </Field>
+              <Field label="Requester Name">
+                <Input value={requesterName} onChange={(e)=> setRequesterName(e.target.value)} />
               </Field>
               <div className="sm:col-span-2 grid gap-2">
                 <Label>Document *</Label>

--- a/client/pages/PurchaseRequest.tsx
+++ b/client/pages/PurchaseRequest.tsx
@@ -312,13 +312,7 @@ function EditPR({
                     <Field label="Total Price *">
                       <Input value={it.total} readOnly />
                     </Field>
-                    <Field label="TDS %">
-                      <PercentCombobox
-                        value={it.tdsRate || ""}
-                        options={["1", "2"]}
-                        onChange={(v) => updateAndRecalc(setItems, idx, { tdsRate: v })}
-                      />
-                    </Field>
+
                     <Field label="GST %">
                       <PercentCombobox
                         value={it.gstRate || ""}
@@ -576,13 +570,7 @@ function CreatePR({ onSave }: { onSave: (p: PR) => void }) {
                     <Field label="Total Price *">
                       <Input value={it.total} readOnly />
                     </Field>
-                    <Field label="TDS %">
-                      <PercentCombobox
-                        value={it.tdsRate || ""}
-                        options={["1", "2"]}
-                        onChange={(v) => updateAndRecalc(setItems, idx, { tdsRate: v })}
-                      />
-                    </Field>
+
                     <Field label="GST %">
                       <PercentCombobox
                         value={it.gstRate || ""}

--- a/client/pages/PurchaseRequest.tsx
+++ b/client/pages/PurchaseRequest.tsx
@@ -134,6 +134,7 @@ function EditPR({
   const [title, setTitle] = useState(value.title);
   const [vendorId, setVendorId] = useState(value.vendorId);
   const [requestDate, setRequestDate] = useState(value.requestDate);
+  const [requesterName, setRequesterName] = useState((value as any).requesterName || "");
   const [document, setDocument] = useState<File | null>(null);
   const [items, setItems] = useState<PRItem[]>(value.items);
   const { vendors } = useExpense();
@@ -151,6 +152,7 @@ function EditPR({
       title: title.trim(),
       vendorId,
       requestDate,
+      requesterName: requesterName || undefined,
       documentName: document?.name || value.documentName,
       items,
     };
@@ -202,6 +204,9 @@ function EditPR({
                   value={requestDate}
                   onChange={(e) => setRequestDate(e.target.value)}
                 />
+              </Field>
+              <Field label="Requester Name">
+                <Input value={requesterName} onChange={(e)=> setRequesterName(e.target.value)} />
               </Field>
               <div className="sm:col-span-2 grid gap-2">
                 <Label>Document</Label>

--- a/client/pages/PurchaseRequest.tsx
+++ b/client/pages/PurchaseRequest.tsx
@@ -245,7 +245,7 @@ function EditPR({
                         <SelectContent>
                           {allExpenseAccounts.map((acc) => (
                             <SelectItem key={acc} value={acc}>
-                              {acc}
+                              {(useExpense().accounts.find((a)=>a.id===acc)?.name || acc)}
                             </SelectItem>
                           ))}
                         </SelectContent>
@@ -511,7 +511,7 @@ function CreatePR({ onSave }: { onSave: (p: PR) => void }) {
                         <SelectContent>
                           {allExpenseAccounts.map((acc) => (
                             <SelectItem key={acc} value={acc}>
-                              {acc}
+                              {(useExpense().accounts.find((a)=>a.id===acc)?.name || acc)}
                             </SelectItem>
                           ))}
                         </SelectContent>

--- a/client/pages/VendorDetails.tsx
+++ b/client/pages/VendorDetails.tsx
@@ -47,7 +47,7 @@ export default function VendorDetails() {
                   <Field label="Email" value={v.email} />
                   <Field label="Phone" value={v.phone} />
                   <Field label="State" value={v.state} />
-                  <Field label="Vendor Type" value={v.vendorTypeId} />
+                  <Field label="Vendor Category" value={(v as any).vendorCategory} />
                   <Field label="Legal Type" value={v.legalType} />
                   <div className="sm:col-span-3">
                     <Field label="Address" value={v.address} />
@@ -64,7 +64,6 @@ export default function VendorDetails() {
                   <Field label="GSTIN" value={v.compliance?.gstin} />
                   <Field label="PAN" value={v.compliance?.pan} />
                   <Field label="TAN" value={v.compliance?.tan} />
-                  <Field label="TDS Section" value={v.compliance?.tdsSection} />
                   <Field label="TDS Rate" value={v.compliance?.tdsRate} />
                   <Field label="GST Rate" value={v.compliance?.gstRate} />
                 </div>

--- a/client/pages/VendorEdit.tsx
+++ b/client/pages/VendorEdit.tsx
@@ -20,7 +20,7 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
 export default function VendorEdit() {
   const { id } = useParams();
   const navigate = useNavigate();
-  const { vendors, vendorTypes, updateVendor } = useExpense();
+  const { vendors, updateVendor } = useExpense();
   const initial = useMemo(() => vendors.find((x) => x.id === id), [vendors, id]);
 
   const [name, setName] = useState("");
@@ -31,7 +31,8 @@ export default function VendorEdit() {
   const [state, setState] = useState("");
   const [active, setActive] = useState(true);
   const [legalType, setLegalType] = useState("");
-  const [vendorTypeId, setVendorTypeId] = useState("");
+  const [vendorCategory, setVendorCategory] = useState<"Service Based"|"Goods Based"|"Both"|"">("");
+  const [serviceType, setServiceType] = useState("");
   const [accountType, setAccountType] = useState("");
   const [oneTime, setOneTime] = useState(false);
   const [startDate, setStartDate] = useState("");
@@ -47,7 +48,8 @@ export default function VendorEdit() {
     setState(initial.state || "");
     setActive(initial.active ?? true);
     setLegalType(initial.legalType || "");
-    setVendorTypeId(initial.vendorTypeId || "");
+    setVendorCategory((initial as any).vendorCategory || "");
+    setServiceType((initial as any).serviceType || "");
     setAccountType((initial as any).accountType || "");
     setOneTime(initial.oneTime ?? false);
     setStartDate(initial.startDate || "");
@@ -67,7 +69,8 @@ export default function VendorEdit() {
       state: state || undefined,
       active,
       legalType: legalType || undefined,
-      vendorTypeId: vendorTypeId || undefined,
+      vendorCategory: vendorCategory || undefined as any,
+      serviceType: serviceType || undefined,
       startDate: startDate || undefined,
       endDate: endDate || undefined,
       oneTime,
@@ -121,19 +124,20 @@ export default function VendorEdit() {
                       </SelectContent>
                     </Select>
                   </Field>
-                  <Field label="Vendor Type">
-                    <Select value={vendorTypeId} onValueChange={setVendorTypeId}>
+                  <Field label="Vendor Category">
+                    <Select value={vendorCategory} onValueChange={(v)=>setVendorCategory(v as any)}>
                       <SelectTrigger>
-                        <SelectValue placeholder="Select Vendor Type" />
+                        <SelectValue placeholder="Select Category" />
                       </SelectTrigger>
                       <SelectContent>
-                        {vendorTypes.map((t) => (
-                          <SelectItem key={t.id} value={t.id}>
-                            {t.name}
-                          </SelectItem>
-                        ))}
+                        <SelectItem value="Service Based">Service Based</SelectItem>
+                        <SelectItem value="Goods Based">Goods Based</SelectItem>
+                        <SelectItem value="Both">Both</SelectItem>
                       </SelectContent>
                     </Select>
+                  </Field>
+                  <Field label="Service Type">
+                    <Input value={serviceType} onChange={(e)=>setServiceType(e.target.value)} />
                   </Field>
                   <Field label="Account Type">
                     <Select value={accountType} onValueChange={setAccountType}>

--- a/client/pages/Vendors.tsx
+++ b/client/pages/Vendors.tsx
@@ -537,6 +537,30 @@ function VendorDialog({
                   </div>
                 </>
               )}
+              <div className="sm:col-span-2 grid gap-2">
+                <Label>Other Documents</Label>
+                <label className="grid h-28 place-items-center rounded-md border-2 border-dashed text-sm text-muted-foreground">
+                  <div className="pointer-events-none select-none text-center">
+                    <div className="font-medium text-foreground">Upload</div>
+                  </div>
+                  <input
+                    type="file"
+                    className="hidden"
+                    multiple
+                    onChange={(e) => {
+                      const files = Array.from(e.target.files || []);
+                      if (files.length) setOtherDocs((s) => [...s, ...files]);
+                    }}
+                  />
+                </label>
+                {otherDocs.length > 0 && (
+                  <ul className="list-disc pl-5 text-sm">
+                    {otherDocs.map((d,i)=> (
+                      <li key={i}>{d.name}</li>
+                    ))}
+                  </ul>
+                )}
+              </div>
             </div>
           </Section>
 

--- a/client/pages/Vendors.tsx
+++ b/client/pages/Vendors.tsx
@@ -85,13 +85,10 @@ interface ExpenseAccountOption {
 import { useExpense, Vendor as StoreVendor } from "@/store/expense";
 
 export default function Vendors() {
-  const { vendors, addVendor, updateVendor, removeVendor } =
+  const { vendors, addVendor, updateVendor, removeVendor, accounts } =
     useExpense();
   const [q, setQ] = useState("");
-  const expenseOptions = [
-    { id: "ACC1", name: "Account 1" },
-    { id: "ACC2", name: "Account 2" },
-  ];
+  const expenseOptions = useMemo(() => accounts.map((a)=>({ id: a.id, name: a.name })), [accounts]);
 
   const filtered = useMemo(
     () => vendors.filter((v) => v.name.toLowerCase().includes(q.toLowerCase())),

--- a/client/pages/Vendors.tsx
+++ b/client/pages/Vendors.tsx
@@ -148,10 +148,7 @@ export default function Vendors() {
                   <TableCell>{(v as any).serviceType || "—"}</TableCell>
                   <TableCell>
                     {v.expenseAccounts
-                      .map(
-                        (x) =>
-                          expenseOptions.find((o) => o.id === x)?.name || x,
-                      )
+                      .map((x) => (accounts.find((a)=>a.id===x)?.name || x))
                       .join(", ")}
                   </TableCell>
                   <TableCell>{v.startDate || "—"}</TableCell>

--- a/client/store/expense.tsx
+++ b/client/store/expense.tsx
@@ -134,8 +134,12 @@ export interface PaymentVoucher {
 }
 
 export interface ExpenseAccount {
-  id: string;
+  id: string; // GL Account No (unique id)
   name: string;
+  groupId?: string;
+  budget?: number;
+  active?: boolean;
+  createdAt?: string;
 }
 
 export interface DebitNote {

--- a/client/store/expense.tsx
+++ b/client/store/expense.tsx
@@ -133,6 +133,11 @@ export interface PaymentVoucher {
   total: number;
 }
 
+export interface ExpenseAccount {
+  id: string;
+  name: string;
+}
+
 export interface DebitNote {
   id: string;
   prId: string;
@@ -155,6 +160,7 @@ interface ExpenseStore {
   invoices: Invoice[];
   vouchers: PaymentVoucher[];
   debitNotes: DebitNote[];
+  accounts: ExpenseAccount[];
   addVendor(v: Vendor): void;
   updateVendor(v: Vendor): void;
   removeVendor(id: string): void;
@@ -166,6 +172,9 @@ interface ExpenseStore {
   addInvoice(inv: Invoice): void;
   addVoucher(v: PaymentVoucher): void;
   addDebitNote(d: DebitNote): void;
+  addAccount(a: ExpenseAccount): void;
+  updateAccount(a: ExpenseAccount): void;
+  removeAccount(id: string): void;
 }
 
 const ExpenseContext = createContext<ExpenseStore | null>(null);
@@ -179,6 +188,7 @@ export function ExpenseProvider({ children }: { children: ReactNode }) {
   const [invoices, setInvoices] = useState<Invoice[]>([]);
   const [vouchers, setVouchers] = useState<PaymentVoucher[]>([]);
   const [debitNotes, setDebitNotes] = useState<DebitNote[]>([]);
+  const [accounts, setAccounts] = useState<ExpenseAccount[]>([]);
 
   useEffect(() => {
     try {
@@ -191,14 +201,15 @@ export function ExpenseProvider({ children }: { children: ReactNode }) {
         setInvoices(data.invoices || []);
         setVouchers(data.vouchers || []);
         setDebitNotes(data.debitNotes || []);
+        setAccounts(data.accounts || []);
       }
     } catch {}
   }, []);
 
   useEffect(() => {
-    const data = { vendors, vendorTypes, prs, invoices, vouchers, debitNotes };
+    const data = { vendors, vendorTypes, prs, invoices, vouchers, debitNotes, accounts };
     localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
-  }, [vendors, vendorTypes, prs, invoices, vouchers, debitNotes]);
+  }, [vendors, vendorTypes, prs, invoices, vouchers, debitNotes, accounts]);
 
   const value = useMemo<ExpenseStore>(
     () => ({
@@ -208,6 +219,7 @@ export function ExpenseProvider({ children }: { children: ReactNode }) {
       invoices,
       vouchers,
       debitNotes,
+      accounts,
       addVendor: (v) => setVendors((s) => [...s, v]),
       updateVendor: (v) =>
         setVendors((s) => s.map((x) => (x.id === v.id ? v : x))),
@@ -222,8 +234,11 @@ export function ExpenseProvider({ children }: { children: ReactNode }) {
       addInvoice: (inv) => setInvoices((s) => [...s, inv]),
       addVoucher: (pv) => setVouchers((s) => [...s, pv]),
       addDebitNote: (d) => setDebitNotes((s) => [...s, d]),
+      addAccount: (a) => setAccounts((s) => [...s, a]),
+      updateAccount: (a) => setAccounts((s) => s.map((x) => (x.id === a.id ? a : x))),
+      removeAccount: (id) => setAccounts((s) => s.filter((x) => x.id !== id)),
     }),
-    [vendors, vendorTypes, prs, invoices, vouchers],
+    [vendors, vendorTypes, prs, invoices, vouchers, accounts],
   );
 
   return (

--- a/client/store/expense.tsx
+++ b/client/store/expense.tsx
@@ -128,7 +128,7 @@ export interface PaymentVoucher {
   depositSlipNumber?: string;
   // Optional linkage/context
   prId?: string; // Linked PR when applicable
-  source?: "Invoice" | "PO" | "None"; // Payment source context
+  source?: "Invoice" | "General" | "PO" | "None"; // Payment source context
   invoiceAmounts: PaymentInvoiceAmount[];
   total: number;
 }

--- a/client/store/expense.tsx
+++ b/client/store/expense.tsx
@@ -18,6 +18,7 @@ export interface PRItem {
   unitPrice: number;
   total: number;
   description?: string;
+  hsnCode?: string;
   gstRate?: string;
   tdsRate?: string;
   gstAmount?: number;
@@ -29,6 +30,7 @@ export interface PR {
   title: string;
   vendorId: string;
   requestDate: string;
+  requesterName?: string;
   documentName?: string;
   poNumber?: string;
   poDocumentName?: string;
@@ -60,7 +62,8 @@ export interface Vendor {
   state?: string;
   active: boolean;
   legalType?: string;
-  vendorTypeId?: string;
+  vendorCategory?: "Service Based" | "Goods Based" | "Both";
+  serviceType?: string;
   accountType?: string;
   startDate?: string;
   endDate?: string;
@@ -71,7 +74,6 @@ export interface Vendor {
     gstin?: string;
     pan?: string;
     tan?: string;
-    tdsSection?: string;
     tdsRate?: string;
     gstRate?: string;
     msme?: boolean;
@@ -84,6 +86,7 @@ export interface Vendor {
     aadhaarName?: string;
     nonGstDocName?: string;
     msmeDocName?: string;
+    otherDocNames?: string[];
   };
   bank: VendorBank[];
 }


### PR DESCRIPTION
## Purpose
The user requested that when expense accounts are called/referenced, the created expense account name should be listed instead of just showing the account ID. This improves usability by displaying human-readable account names rather than cryptic IDs.

## Code changes
- **Invoice Creation**: Modified `CreateInvoice.tsx` to display expense account names in the dropdown instead of account IDs by looking up the account name from the expense store
- **Expense Management**: Integrated expense accounts into the global expense store with CRUD operations (add, update, remove)
- **UI Improvements**: Added new required fields (HSN Code, TDS Section) to invoice line items and updated validation
- **Vendor Management**: Enhanced vendor form with new fields like vendor category, service type, and document uploads
- **Code Cleanup**: Removed unused VendorTypes page and related routing
- **Data Structure**: Updated interfaces to support new fields and removed deprecated HSN/SAC code from expense accountsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b7df3493ab174047a719498cef55278f/zenith-haven)

👀 [Preview Link](https://b7df3493ab174047a719498cef55278f-zenith-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b7df3493ab174047a719498cef55278f</projectId>-->
<!--<branchName>zenith-haven</branchName>-->